### PR TITLE
MusicXML全形式対応: .mxl, .xml, .musicxml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mrev - MusicXML Score Reverser
 
-MusicXML (.mxl) ファイルを「逆から演奏できる」スコアに変換するツール。
+MusicXML (.mxl / .xml / .musicxml) ファイルを「逆から演奏できる」スコアに変換するツール。
 
 ## 機能
 
@@ -17,15 +17,28 @@ pip install -r requirements.txt
 
 ## 使い方
 
+### 対応形式
+
+- `.mxl` (圧縮MusicXML)
+- `.xml` (非圧縮MusicXML)
+- `.musicxml` (非圧縮MusicXML)
+
+入力ファイルの形式はそのまま出力にも保持されます（.mxl → .mxl、.xml → .xml）。
+
 ### 基本的な使い方
 
-1. `work/inbox/` に MXL ファイルを配置
+1. `work/inbox/` に MusicXML ファイル (.mxl / .xml / .musicxml) を配置
 2. スクリプトを実行
 3. `work/outbox/` に反転されたファイルが出力される
 
 ```bash
 python reverse_score.py
 ```
+
+例:
+- `work/inbox/score.mxl` → `work/outbox/score_rev.mxl`
+- `work/inbox/score.xml` → `work/outbox/score_rev.xml`
+- `work/inbox/score.musicxml` → `work/outbox/score_rev.musicxml`
 
 ### オプション
 

--- a/reverse_score.py
+++ b/reverse_score.py
@@ -333,7 +333,9 @@ def process_file(input_path: Path, output_path: Path,
 
         # 出力ファイルを書き出し（エラー時はスキップして続行）
         try:
-            reversed_score.write('mxl', fp=str(output_path))
+            # 入力ファイルの形式に応じて出力形式を決定
+            output_format = 'mxl' if input_path.suffix == '.mxl' else 'xml'
+            reversed_score.write(output_format, fp=str(output_path))
             print(f"  出力: {output_path.name}")
         except Exception as write_error:
             # 書き出しエラーの詳細を解析してレポートに追加
@@ -410,7 +412,9 @@ def write_with_fallback(score: stream.Score, output_path: Path, report: Processi
 
     # 修正後に書き出しを試行
     try:
-        score.write('mxl', fp=str(output_path))
+        # output_path から形式を判定
+        output_format = 'mxl' if output_path.suffix == '.mxl' else 'xml'
+        score.write(output_format, fp=str(output_path))
         return True
     except Exception:
         # それでもダメな場合はパート単位でスキップ
@@ -472,7 +476,9 @@ def write_with_part_fallback(score: stream.Score, output_path: Path, report: Pro
         new_score.append(part)
 
     try:
-        new_score.write('mxl', fp=str(output_path))
+        # output_path から形式を判定
+        output_format = 'mxl' if output_path.suffix == '.mxl' else 'xml'
+        new_score.write(output_format, fp=str(output_path))
         return True
     except Exception:
         return False
@@ -500,21 +506,23 @@ def main():
 
     outbox.mkdir(parents=True, exist_ok=True)
 
-    # MXL ファイルを検索
-    mxl_files = list(inbox.glob("*.mxl"))
+    # MusicXML ファイルを検索 (.mxl, .xml, .musicxml)
+    input_files = []
+    for pattern in ["*.mxl", "*.xml", "*.musicxml"]:
+        input_files.extend(inbox.glob(pattern))
 
-    if not mxl_files:
-        print(f"MXL ファイルが見つかりません: {inbox}")
+    if not input_files:
+        print(f"MusicXML ファイルが見つかりません: {inbox}")
         sys.exit(0)
 
-    print(f"処理対象: {len(mxl_files)} ファイル\n")
+    print(f"処理対象: {len(input_files)} ファイル\n")
 
     success_count = 0
     all_reports: list[ProcessingReport] = []
 
-    for input_path in mxl_files:
-        # 出力ファイル名を生成
-        output_name = input_path.stem + "_rev.mxl"
+    for input_path in input_files:
+        # 出力ファイル名を生成（入力形式を保持）
+        output_name = input_path.stem + "_rev" + input_path.suffix
         output_path = outbox / output_name
 
         report = process_file(input_path, output_path, error_handling)
@@ -524,7 +532,7 @@ def main():
             success_count += 1
         print()
 
-    print(f"完了: {success_count}/{len(mxl_files)} ファイル処理成功")
+    print(f"完了: {success_count}/{len(input_files)} ファイル処理成功")
 
     # 問題レポートを出力
     reports_with_issues = [r for r in all_reports if r.has_issues()]


### PR DESCRIPTION
## Summary

現在の reverse_score.py は .mxl (圧縮MusicXML) ファイルのみを処理対象としていたが、非圧縮の .xml および .musicxml ファイルも受け付けるよう拡張。

入力形式を維持して出力する（.mxl → .mxl, .xml → .xml, .musicxml → .musicxml）。

Closes #1

## Changes

### reverse_score.py

- **ファイル検索の拡張** (main関数 L503-510):
  - `*.mxl`, `*.xml`, `*.musicxml` の3形式を検索
  - 変数名を `mxl_files` → `input_files` に変更

- **出力ファイル名の形式保持** (main関数 L516-518):
  - `input_path.suffix` を使用して入力形式を保持

- **動的な出力形式決定**:
  - `process_file()` (L336): 入力形式に応じて `'mxl'` または `'xml'` を選択
  - `write_with_fallback()` (L413): 出力パスから形式を判定
  - `write_with_part_fallback()` (L475): 出力パスから形式を判定

### README.md

- タイトル: 「MXL ファイル」→「MXL / XML / MUSICXML ファイル」
- 対応形式セクション追加: 3形式の説明と形式保持の動作
- 使用例追加: 各形式での入出力例

## Test Results

### 基本テスト（3形式すべて処理）

```
処理対象: 3 ファイル

処理中: pomp-and-circumstance-march-no-1.mxl
  出力: pomp-and-circumstance-march-no-1_rev.mxl

処理中: test-simple.xml
  出力: test-simple_rev.xml

処理中: test-simple.musicxml
  出力: test-simple_rev.musicxml

完了: 3/3 ファイル処理成功
```

### ファイル形式検証

```bash
$ file work/outbox/*.{mxl,xml,musicxml}
pomp-and-circumstance-march-no-1_rev.mxl: Zip archive data (圧縮)
test-simple_rev.xml:                       XML 1.0 document (非圧縮)
test-simple_rev.musicxml:                  XML 1.0 document (非圧縮)
```

✅ 形式が正しく保持されていることを確認

### -s オプションテスト

```
処理対象: 3 ファイル
完了: 3/3 ファイル処理成功
```

✅ エラーハンドリングモードでもすべての形式が正常動作

## Backward Compatibility

✅ 既存の .mxl ファイル処理は完全に維持
✅ 既存オプション・エラーハンドリングに影響なし