### PR TITLE
音部記号・調号・拍子記号を反転後も保持する

### DIFF
--- a/reverse_score.py
+++ b/reverse_score.py
@@ -171,6 +171,27 @@ def reverse_part(part: stream.Part, report: ProcessingReport | None = None) -> s
     for inst in part.getElementsByClass('Instrument'):
         new_part.insert(0, inst)
 
+    # 音部記号をコピー (Clef)
+    clefs = first_original_measure.getElementsByClass('Clef')
+    if clefs:
+        first_clef = clefs.first()
+        if first_clef:
+            new_part.insert(0, first_clef)
+
+    # 調号をコピー (KeySignature)
+    key_sigs = first_original_measure.getElementsByClass('KeySignature')
+    if key_sigs:
+        first_key = key_sigs.first()
+        if first_key:
+            new_part.insert(0, first_key)
+
+    # 拍子記号をコピー (TimeSignature)
+    time_sigs = first_original_measure.getElementsByClass('TimeSignature')
+    if time_sigs:
+        first_time = time_sigs.first()
+        if first_time:
+            new_part.insert(0, first_time)
+
     # 各小節を処理して追加
     for i, measure in enumerate(reversed_measures):
         original_measure_num = measure.number


### PR DESCRIPTION
## Summary

Violaの譜面を反転処理するとアルト記号（ハ音記号/C clef）がト音記号（G clef）に変換されてしまう問題を修正。

## Changes

`reverse_score.py` の `reverse_part` 関数に以下のコピー処理を追加：
- 音部記号（Clef）
- 調号（KeySignature）
- 拍子記号（TimeSignature）

これにより、反転後も元のスコアの記譜情報がすべて保持されるようになった。

## Verification

### ✅ Viola AltoClefの保持
```
元のファイル: Violas: AltoClef (sign=C, line=3)
反転後:      Violas: AltoClef (sign=C, line=3)
```

### ✅ すべての音部記号タイプの保持
- TrebleClef, BassClef, AltoClef, Treble8vaClef, Bass8vbClef, PercussionClef
- すべて正しく保持されることを確認

### ✅ 調号・拍子記号の保持
- 移調楽器の調号（例: A Clarinet の -1 sharps）
- 拍子記号（2/4拍子）
- すべて正しく保持されることを確認

### ✅ 既存機能の回帰なし
- 33パートの大規模スコア（Pomp and Circumstance）で正常動作
- エラーハンドリングモードで正常動作

## Test Files
- `work/inbox/pomp-and-circumstance-march-no-1.mxl` (33パート、Violaを含む)
- `work/outbox/pomp-and-circumstance-march-no-1_rev.mxl` (反転後の出力)

Closes #3