### PR TITLE
強弱記号・テキスト表現のオフセット反転を実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ MusicXML (.mxl / .xml / .musicxml) ファイルを「逆から演奏できる」
 
 - 小節順序を反転
 - 各小節内の音符オフセットを反転
+- 強弱記号（f, p等）、テキスト表現、テンポ指示、リハーサルマークのオフセットを反転
 - Crescendo ↔ Diminuendo を変換
 - タイの start/stop を反転
 

--- a/reverse_score.py
+++ b/reverse_score.py
@@ -86,7 +86,7 @@ def reverse_note_offset(element, measure_duration: float) -> None:
 
 
 def reverse_measure_contents(measure: stream.Measure) -> tuple[stream.Measure, str | None]:
-    """小節内の音符・休符のオフセットを反転する
+    """小節内の音符・休符・表現記号のオフセットを反転する
 
     Returns:
         tuple: (処理後の小節, エラーメッセージ or None)
@@ -98,6 +98,11 @@ def reverse_measure_contents(measure: stream.Measure) -> tuple[stream.Measure, s
     try:
         # 音符、休符、和音を取得して反転
         for element in measure.notesAndRests:
+            reverse_note_offset(element, measure_duration)
+
+        # 表現記号（Dynamics, TextExpression等）を反転
+        for element in measure.getElementsByClass(['Dynamic', 'TextExpression',
+                                                    'TempoText', 'RehearsalMark']):
             reverse_note_offset(element, measure_duration)
 
         # 要素をオフセット順にソート


### PR DESCRIPTION
## 概要
MusicXML反転ツールで、強弱記号（f, p等）やテキスト表現の位置が反転されない問題を修正しました。

## 変更内容
- `reverse_measure_contents` 関数に表現記号の反転処理を追加
- 対象要素: Dynamic（強弱記号）、TextExpression、TempoText、RehearsalMark
- 既存の `reverse_note_offset()` 関数を再利用（新規関数不要）

## 実装方針
- duration=0.0の要素に対しても既存公式が正しく機能
- 最小限の変更（4行追加のみ）
- 既存の音符反転処理に影響なし

## 検証結果
✅ test-dynamics.xml で強弱記号が正しく反転されることを確認
- 元: 小節1のf（offset=0.0）→ 反転後: 小節2でoffset=4.0
- 元: 小節2のp（offset=2.0）→ 反転後: 小節1でoffset=2.0

✅ 大規模スコア（pomp-and-circumstance-march-no-1.mxl）で回帰テスト成功
✅ skip-measure-content モード（-s）でも正常動作

## 変更ファイル
- `reverse_score.py` — 4行追加（L103-107）
- `README.md` — 機能説明を1行追加

Closes #5