### PR TITLE
octave-shift要素の処理不良を修正

### DIFF
--- a/reverse_score.py
+++ b/reverse_score.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from music21 import converter, stream, dynamics, tie, spanner
+from music21.spanner import Ottava
 
 
 @dataclass
@@ -174,10 +175,18 @@ def reverse_part(part: stream.Part, report: ProcessingReport | None = None) -> s
                     break
 
         if len(note_positions) == len(spanned_elements_original):
-            spanner_info.append({
+            sp_data = {
                 'type': sp.__class__,
                 'positions': note_positions
-            })
+            }
+
+            # Ottavaの場合、追加のプロパティを保存
+            if isinstance(sp, Ottava):
+                sp_data['ottava_type'] = sp.type
+                sp_data['transposing'] = sp.transposing
+                sp_data['placement'] = sp.placement
+
+            spanner_info.append(sp_data)
 
     # SKIP_MEASURE_CONTENT モードでは元の小節を保持
     if error_handling == ErrorHandling.SKIP_MEASURE_CONTENT:
@@ -338,6 +347,13 @@ def reverse_part(part: stream.Part, report: ProcessingReport | None = None) -> s
                 )
             )
             new_spanner = sp_info['type'](new_spanned_elements_sorted)
+
+            # Ottavaの場合、保存したプロパティを復元
+            if isinstance(new_spanner, Ottava):
+                new_spanner.type = sp_info.get('ottava_type', '8va')
+                new_spanner.transposing = sp_info.get('transposing', False)
+                new_spanner.placement = sp_info.get('placement', 'above')
+
             new_part.insert(0, new_spanner)
 
     # ダイナミクスのウェッジを反転


### PR DESCRIPTION
## 概要
反転→再反転テストで octave-shift 要素を含む楽譜が正しく復元されない問題を修正しました。

## 問題
- 威風堂々ラスト_in-Violin.mxl を反転→再反転した結果、パート1の小節2-4で2〜3オクターブ音高が上昇
- 例: C#6 → C#8, E6 → E9

## 原因
- Ottava spanner の固有プロパティ（type, transposing, placement）が保存されていなかった
- music21 が octave-shift をインポート時に警告を出していたが、実際には MusicXML 要素は保存されていた

## 修正内容
- Ottava クラスをインポート
- Ottava spanner の固有プロパティを保存・復元する処理を追加
  - `ottava_type`
  - `transposing`
  - `placement`

## 検証結果
**反転→再反転テスト（威風堂々ラスト_in-Violin.mxl）:**
- ✅ 全小節で音符が完全一致（ピッチ・リズム・オフセット）
- ✅ MusicXMLの `<octave-shift>` 要素も正しく保存

### 修正前
```
小節 2: C#6 -> C#8 (+2オクターブ)
小節 2: D6 -> D8 (+2オクターブ)
小節 2: E6 -> E9 (+3オクターブ)
小節 3: B5 -> B7 (+2オクターブ)
小節 4: A5 -> A7 (+2オクターブ)
```

### 修正後
```
小節 2: [OK] 完全一致
小節 3: [OK] 完全一致
小節 4: [OK] 完全一致
全小節で音符が完全一致！
```

## 既知の制限
- Ottava spanner の個数が減少する場合がある（元3個→2個に統合）
- 音符マッチングの問題だが、演奏内容には影響しない

## テストファイル
- work/inbox/test/威風堂々ラスト_in-Violin.mxl

関連: #10