### PR TITLE
連符（tuplet）の反転処理を実装

### DIFF
--- a/reverse_score.py
+++ b/reverse_score.py
@@ -135,6 +135,17 @@ def reverse_beams(element) -> None:
                 # 'continue' と 'partial' はそのまま維持
 
 
+def reverse_tuplets(element) -> None:
+    """連符の start/stop を反転する"""
+    if hasattr(element, 'duration') and element.duration.tuplets:
+        for tuplet in element.duration.tuplets:
+            if tuplet.type == 'start':
+                tuplet.type = 'stop'
+            elif tuplet.type == 'stop':
+                tuplet.type = 'start'
+            # None や 'continue' はそのまま維持
+
+
 def reverse_dynamics_wedges(part: stream.Part) -> None:
     """Crescendo ↔ Diminuendo を変換する"""
     spanners_to_process = list(part.spannerBundle)
@@ -322,10 +333,12 @@ def reverse_part(part: stream.Part, report: ProcessingReport | None = None) -> s
                 for element in fallback.notesAndRests:
                     reverse_ties(element)
                     reverse_beams(element)
+                    reverse_tuplets(element)
                     if hasattr(element, 'notes'):
                         for note in element.notes:
                             reverse_ties(note)
                             reverse_beams(note)
+                            reverse_tuplets(note)
                 new_part.append(fallback)
                 continue
 
@@ -333,11 +346,13 @@ def reverse_part(part: stream.Part, report: ProcessingReport | None = None) -> s
         for element in processed_measure.notesAndRests:
             reverse_ties(element)
             reverse_beams(element)
+            reverse_tuplets(element)
             # 和音内の音符のタイと連桁も処理
             if hasattr(element, 'notes'):
                 for note in element.notes:
                     reverse_ties(note)
                     reverse_beams(note)
+                    reverse_tuplets(note)
 
             # 小節番号を再割り当て
         processed_measure.number = i + 1

--- a/test_tuplet_with_reverse_score.py
+++ b/test_tuplet_with_reverse_score.py
@@ -1,0 +1,104 @@
+"""reverse_score.py を使った連符反転テスト"""
+from music21 import stream, note, converter
+import sys
+sys.path.insert(0, '.')
+from reverse_score import reverse_part
+
+def create_test_score_with_tuplets():
+    """様々な連符を含むテストスコアを作成"""
+    s = stream.Score()
+    p = stream.Part(id='P1')
+    
+    m1 = stream.Measure(number=1)
+    # 3連符（triplet）
+    for i in range(3):
+        n = note.Note('C4', quarterLength=2.0/3)
+        m1.append(n)
+    
+    m2 = stream.Measure(number=2)
+    # 5連符
+    for i in range(5):
+        n = note.Note('D4', quarterLength=4.0/5)
+        m2.append(n)
+    
+    m3 = stream.Measure(number=3)
+    # 11連符
+    for i in range(11):
+        n = note.Note('E4', quarterLength=4.0/11)
+        m3.append(n)
+    
+    p.append([m1, m2, m3])
+    s.append(p)
+    return s
+
+def analyze_tuplets(s, label):
+    """連符情報を詳細に分析"""
+    print(f"\n=== {label} ===")
+    for part in s.parts:
+        print(f"Part {part.id}:")
+        for measure in part.getElementsByClass('Measure'):
+            print(f"  Measure {measure.number}:")
+            notes = measure.flatten().notes
+            for n in notes:
+                if n.duration.tuplets:
+                    tuplet_info = []
+                    for t in n.duration.tuplets:
+                        tuplet_info.append(
+                            f"{t.numberNotesActual}:{t.numberNotesNormal} "
+                            f"type={t.type}"
+                        )
+                    print(f"    {n.nameWithOctave} QL={n.quarterLength:.4f} "
+                          f"Tuplets={', '.join(tuplet_info)}")
+                else:
+                    print(f"    {n.nameWithOctave} QL={n.quarterLength:.4f} "
+                          f"(no tuplet)")
+
+# テスト実行
+print("reverse_score.py を使った連符反転テスト")
+original = create_test_score_with_tuplets()
+
+# MusicXML経由でロード（music21が連符のtype情報を付与）
+original.write('musicxml', 'work/test_tuplets_orig.musicxml')
+loaded = converter.parse('work/test_tuplets_orig.musicxml')
+analyze_tuplets(loaded, "Original (after MusicXML roundtrip)")
+
+# reverse_score.py でパートを反転
+print("\n=== Reversing using reverse_score.py ===")
+reversed_part = reverse_part(loaded.parts[0])
+reversed_score = stream.Score()
+reversed_score.append(reversed_part)
+analyze_tuplets(reversed_score, "After reverse_part()")
+
+# 反転後のスコアを保存・再読み込み
+reversed_score.write('musicxml', 'work/test_tuplets_reversed_by_script.musicxml')
+reloaded = converter.parse('work/test_tuplets_reversed_by_script.musicxml')
+analyze_tuplets(reloaded, "After reversed MusicXML roundtrip")
+
+# 結果の検証
+print("\n=== Validation ===")
+all_ok = True
+for part in reloaded.parts:
+    for measure in part.getElementsByClass('Measure'):
+        notes = list(measure.flatten().notes)
+        if not notes:
+            continue
+        
+        # 最初の音符は type=start を持つべき
+        first_tuplets = notes[0].duration.tuplets
+        if first_tuplets:
+            if first_tuplets[0].type != 'start':
+                print(f"[FAIL] Measure {measure.number}: first note type is {first_tuplets[0].type}, expected start")
+                all_ok = False
+        
+        # 最後の音符は type=stop を持つべき
+        last_tuplets = notes[-1].duration.tuplets
+        if last_tuplets:
+            if last_tuplets[0].type != 'stop':
+                print(f"[FAIL] Measure {measure.number}: last note type is {last_tuplets[0].type}, expected stop")
+                all_ok = False
+
+if all_ok:
+    print("[PASS] All tuplets reversed correctly")
+else:
+    print("[FAIL] Tuplet reversal has issues")
+    sys.exit(1)


### PR DESCRIPTION
## 概要

連符（tuplet）の `start` ↔ `stop` を反転する処理を実装しました。

## 問題

連符の反転処理が実装されていなかったため、3連符・5連符・11連符などを含むMusicXMLファイルを反転すると連符情報が破損していました。

## 実装内容

1. **`reverse_tuplets()` 関数を追加**
   - タイ・連桁と同様に、連符の `start` ↔ `stop` を反転
   - `None` や `continue` タイプはそのまま維持

2. **`reverse_part()` 関数内で `reverse_tuplets()` を呼び出し**
   - 小節内容反転後に各音符・和音に適用
   - fallback処理時も同様に適用

## テスト結果

```
=== Original ===
Measure 1: C4 (3:2 type=start) → C4 (type=None) → C4 (type=stop)  [3連符]
Measure 2: D4 (5:4 type=start) → ... → D4 (type=stop)             [5連符]
Measure 3: E4 (11:8 type=start) → ... → E4 (type=stop)            [11連符]

=== After reverse_part() ===
Measure 1: E4 (11:8 type=start) → ... → E4 (type=stop)            [11連符が正しく反転]
Measure 2: D4 (5:4 type=start) → ... → D4 (type=stop)             [5連符が正しく反転]
Measure 3: C4 (3:2 type=start) → ... → C4 (type=stop)             [3連符が正しく反転]

[PASS] All tuplets reversed correctly
```

## 確認事項

- ✅ 3連符、5連符、11連符すべてが正しく反転される
- ✅ MusicXML roundtrip 後も連符情報が保持される
- ✅ すべての連符で `type=start → ... → type=stop` の順序が維持される

Fixes #22