### PR TITLE
Fix tempo instruction duplication by processing MetronomeMark elements

### DIFF
--- a/reverse_score.py
+++ b/reverse_score.py
@@ -103,7 +103,8 @@ def reverse_measure_contents(measure: stream.Measure) -> tuple[stream.Measure, s
 
         # 表現記号（Dynamics, TextExpression等）を反転
         for element in measure.getElementsByClass(['Dynamic', 'TextExpression',
-                                                    'TempoText', 'RehearsalMark']):
+                                                    'TempoText', 'RehearsalMark',
+                                                    'MetronomeMark']):
             reverse_note_offset(element, measure_duration)
 
         # 要素をオフセット順にソート


### PR DESCRIPTION
## Summary
- `reverse_measure_contents()` で `MetronomeMark` 要素のオフセットを反転するようにした
- これにより、`<sound tempo="..."/>` を含むMusicXMLファイルの反転処理後に余分な `<metronome>` 要素が追加されるバグを修正

## Root Cause
music21は `<sound tempo="..."/>` 要素から `MetronomeMark` オブジェクトを自動生成する。このオブジェクトが反転処理の対象外だったため、書き出し時に新たな `<metronome>` 要素として追加されていた。

## Test plan
- [x] `<sound tempo="..."/>` を含むテスト用MusicXMLファイルで反転処理を実行
- [x] 出力ファイルに余分な `<metronome>` 要素が追加されないことを確認

Closes #28