### PR TITLE
ダイナミクスの default-x 変換を削除し音符との位置ずれを修正

### DIFF
--- a/layout_preservation.py
+++ b/layout_preservation.py
@@ -261,31 +261,29 @@ def transform_layout_for_reversal(
     """
     レイアウト座標を反転用に変換
 
+    重要: default-x は変換しない（music21が適切な位置を生成するため）
+    Y座標と placement 属性のみを復元する
+
     Args:
         original_layout: 元のレイアウト情報
-        measure_width: 小節幅（tenths単位）
+        measure_width: 小節幅（tenths単位）- 未使用だが互換性のため保持
 
     Returns:
         ElementLayout: 変換後のレイアウト情報
     """
-    # レイアウトをコピー
     transformed = ElementLayout(
         element_type=original_layout.element_type,
         offset=original_layout.offset,
         pitch=original_layout.pitch,
         text=original_layout.text,
         duration=original_layout.duration,
+        # X座標は変換しない（music21に任せる）
+        default_x=None,
         default_y=original_layout.default_y,      # Y座標はそのまま
-        relative_x=original_layout.relative_x,    # relative座標はそのまま
-        relative_y=original_layout.relative_y,
+        relative_x=None,  # 音符との相対位置も music21 に任せる
+        relative_y=original_layout.relative_y,    # Y方向の相対位置は保持
         placement=original_layout.placement       # placementはそのまま
     )
-
-    # X座標のみ鏡像反転
-    if original_layout.default_x is not None and measure_width is not None:
-        transformed.default_x = measure_width - original_layout.default_x
-    else:
-        transformed.default_x = original_layout.default_x  # 変換不可の場合はそのまま
 
     return transformed
 


### PR DESCRIPTION
## Summary
- `transform_layout_for_reversal()` でダイナミクスの `default-x` と `relative-x` を変換せず `None` に設定
- X座標は music21 の自動配置に任せ、`default-y`, `relative-y`, `placement` のみを復元

Fixes #30

## 問題の原因
- `layout_preservation.py` がダイナミクスの `default-x` を鏡像反転
- 音符の `default-x` は music21 の出力そのまま（反転されていない）
- 結果：ダイナミクスと音符の座標が整合しなくなっていた

## Test plan
- [x] `pytest tests/` で全13テストが PASS
- [x] `reverse_score.py` で威風堂々ラスト_in-Viola.mxl の反転が正常完了
- [x] 出力ファイルで sf の `default-x` が出力されていないことを確認