### PR TITLE
StaffGroup保持とトリル重複修正

### DIFF
--- a/reverse_score.py
+++ b/reverse_score.py
@@ -875,21 +875,36 @@ def reverse_part(part: stream.Part | stream.PartStaff, report: ProcessingReport 
 
             new_part.insert(0, new_spanner)
 
-    # TrillExtensionの開始音符からTrill expressionを削除（重複防止）
-    trill_extension_starts = set()
+    # TrillExtension内の重複Trill expressionをクリーンアップ
+    # 開始音符にはTrillを確保、それ以外の音符からは削除
     for sp in new_part.spannerBundle:
         if isinstance(sp, expressions.TrillExtension):
             spanned = list(sp.getSpannedElements())
-            if spanned:
-                trill_extension_starts.add(id(spanned[0]))
+            if not spanned:
+                continue
 
-    for measure in new_part.getElementsByClass(stream.Measure):
-        for element in measure.notesAndRests:
-            if id(element) in trill_extension_starts and hasattr(element, 'expressions'):
-                element.expressions = [
-                    exp for exp in element.expressions
-                    if not isinstance(exp, expressions.Trill)
-                ]
+            for i, elem in enumerate(spanned):
+                if not hasattr(elem, 'expressions'):
+                    continue
+
+                if i == 0:
+                    # 開始音符: Trillが1つだけあることを保証
+                    existing_trills = [e for e in elem.expressions if isinstance(e, expressions.Trill)]
+                    other_expressions = [e for e in elem.expressions if not isinstance(e, expressions.Trill)]
+
+                    if len(existing_trills) == 0:
+                        # Trillがない場合は追加
+                        elem.expressions = other_expressions + [expressions.Trill()]
+                    elif len(existing_trills) > 1:
+                        # 複数ある場合は1つに削減
+                        elem.expressions = other_expressions + [existing_trills[0]]
+                    # すでに1つある場合は何もしない
+                else:
+                    # 開始音符以外: Trillを削除
+                    elem.expressions = [e for e in elem.expressions if not isinstance(e, expressions.Trill)]
+
+
+
 
     # 小節ベースSpanner（RepeatBracket等）を再構築
     for mb_sp in measure_based_spanners:


### PR DESCRIPTION
## 修正内容

このPRには2つの独立した修正が含まれています：

### 1. StaffGroupとPartStaffの保持 (#33)

**問題**:
- music21がStaffGroupとPartStaffを破棄し、縦レイアウトが崩れる

**修正**:
- 元のXMLからStaffGroupとPartStaff構造を抽出
- music21処理後に元の構造を復元

### 2. トリル重複の修正

**問題**:
- 威風堂々ラスト_in-Concert_Snare_Drum_rev.mxl の6小節目にトリルが重複表示される
- 元ファイル(M48): `<trill-mark/>` + `<wavy-line start/>`
- 反転後(M6): トリルマークが2つ表示される

**根本原因**:
- music21はTrillExtensionスパナーをエクスポート時に開始音符に`<trill-mark/>`を自動追加
- 反転処理で元のM48の音符(Trill expression付き)がM6に移動
- 結果: M6の音符に元のTrill expressionが残り、TrillExtension開始音符(M4)にTrillがない状態

**修正**:
- TrillExtensionの開始音符にTrill expressionを1つ確保（ない場合は追加）
- 開始音符以外の音符からTrill expressionを削除

**検証結果**:
- M4: `<trill-mark/>` 1つ + `<wavy-line start/>`
- M6: `<wavy-line stop/>`のみ
- トリル重複解消を確認

## テスト

- [x] 威風堂々ラスト_in-Concert_Snare_Drumで反転実行
- [x] M4とM6のXML出力確認
- [x] music21でのTrill expression確認
- [x] トリル重複が解消されていることを確認

## 影響範囲

- `reverse_score.py`: TrillExtensionクリーンアップロジック追加
- 他のスパナー（Slur, Crescendo等）への影響なし