### PR TITLE
direction要素をXMLレベルで保存・復元してmusic21分割バグに対応 (Closes #27)

### DIFF
--- a/layout_preservation.py
+++ b/layout_preservation.py
@@ -56,11 +56,30 @@ class TechnicalElement:
 
 
 @dataclass
+class DirectionElement:
+    """Direction要素の保存用（music21が分割するもの）
+
+    music21はMusicXMLのdirection要素を読み込んで書き出す際、
+    words+soundを含む単一のdirection要素を2つに分割してしまう。
+    元のXMLを保存し、反転後に復元することでこの問題を回避する。
+    """
+    measure_num: int
+    element_index: int  # 小節内でのdirection要素の出現順
+    direction_xml: str  # direction要素全体のXML文字列
+    placement: Optional[str] = None  # placement属性
+    has_sound: bool = False  # sound子要素を持つか
+    has_words: bool = False  # words子要素を持つか
+    words_text: Optional[str] = None  # wordsのテキスト内容
+
+
+@dataclass
 class LayoutMap:
     """スコア全体のレイアウト情報"""
     measures: dict[tuple[str, int], MeasureLayout] = field(default_factory=dict)
     # Key: (part_id, measure_number)
     technical_elements: dict[str, list[TechnicalElement]] = field(default_factory=dict)
+    # Key: part_id
+    directions: dict[str, list[DirectionElement]] = field(default_factory=dict)
     # Key: part_id
     defaults_xml: Optional[str] = None  # defaults要素をXML文字列として保存
 
@@ -129,6 +148,7 @@ def extract_layout_from_xml(xml_path: Path) -> LayoutMap:
     for part_idx, part in enumerate(root.findall('.//{*}part')):
         part_id = part.get('id', f'P{part_idx + 1}')
         layout_map.technical_elements[part_id] = []
+        layout_map.directions[part_id] = []
 
         # 各小節を走査
         for measure in part.findall('.//{*}measure'):
@@ -156,6 +176,7 @@ def extract_layout_from_xml(xml_path: Path) -> LayoutMap:
             current_offset = 0.0
             divisions = 1.0  # デフォルト
             note_index = 0  # 小節内の音符インデックス
+            direction_index = 0  # 小節内のdirection要素のインデックス
 
             # attributes要素からdivisionsを取得
             for attributes in measure.findall('.//{*}attributes'):
@@ -170,6 +191,29 @@ def extract_layout_from_xml(xml_path: Path) -> LayoutMap:
             for elem in measure:
                 # direction要素（ダイナミクス、テキストなど）
                 if elem.tag.endswith('direction'):
+                    # direction要素をXMLとして保存（music21分割問題対策）
+                    placement = elem.get('placement')
+                    sound = elem.find('.//{*}sound')
+                    words = elem.find('.//{*}direction-type/{*}words')
+
+                    has_sound = sound is not None
+                    has_words = words is not None
+                    words_text = None
+                    if words is not None and words.text:
+                        words_text = words.text.strip()
+
+                    direction_elem = DirectionElement(
+                        measure_num=measure_num,
+                        element_index=direction_index,
+                        direction_xml=ET.tostring(elem, encoding='unicode'),
+                        placement=placement,
+                        has_sound=has_sound,
+                        has_words=has_words,
+                        words_text=words_text
+                    )
+                    layout_map.directions[part_id].append(direction_elem)
+                    direction_index += 1
+
                     # offset属性（direction要素内のオフセット）
                     offset_elem = elem.find('.//{*}offset')
                     direction_offset = 0.0
@@ -468,6 +512,142 @@ def merge_split_directions(output_xml_path: Path, verbose: bool = False) -> None
 
     if verbose:
         print(f"  Total merged: {merge_count} direction pairs")
+
+    # 変更後のXMLを書き出し
+    if is_mxl:
+        import tempfile
+        import shutil
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_mxl = Path(tmpdir) / 'output.mxl'
+            shutil.copy2(output_xml_path, tmp_mxl)
+
+            xml_content = ET.tostring(root, encoding='utf-8', xml_declaration=True)
+
+            with zipfile.ZipFile(output_xml_path, 'w', compression=zipfile.ZIP_DEFLATED) as zf_out:
+                with zipfile.ZipFile(tmp_mxl, 'r') as zf_in:
+                    for item in zf_in.namelist():
+                        if item == xml_filename:
+                            zf_out.writestr(item, xml_content)
+                        else:
+                            zf_out.writestr(item, zf_in.read(item))
+    else:
+        tree = ET.ElementTree(root)
+        tree.write(output_xml_path, encoding='utf-8', xml_declaration=True)
+
+
+# 経過的テンポパターン（reverse_score.pyからの抜粋）
+# rit., accel.などの一時的な速度変化を示すパターン
+TRANSITIONAL_TEMPO_PATTERNS = [
+    'ritardando', 'rit.', 'rit', 'ritenuto', 'riten.', 'riten',
+    'rallentando', 'rall.', 'rall', 'rallent.',
+    'allargando', 'allarg.', 'allarg',
+    'calando', 'cal.',
+    'smorzando', 'smorz.', 'smorz',
+    'morendo', 'mor.',
+    'perdendosi', 'perd.',
+    'accelerando', 'accel.', 'accel',
+    'stringendo', 'string.', 'string',
+    'affrettando', 'affrett.', 'affrett',
+    'incalzando', 'incalz.', 'incalz',
+    'animando', 'animand.', 'animand',
+    'stretto',
+]
+
+
+def _is_transitional_tempo_text(text: str) -> bool:
+    """テンポ表記が経過的（一時的な変化）かどうかを判定する"""
+    if not text:
+        return False
+    text_lower = text.lower()
+    return any(pattern in text_lower for pattern in TRANSITIONAL_TEMPO_PATTERNS)
+
+
+def restore_direction_elements(
+    output_xml_path: Path,
+    original_layout_map: LayoutMap,
+    total_measures: int
+) -> None:
+    """
+    保存したdirection要素を反転後の小節に復元する
+
+    music21が出力したdirection要素を削除し、元のXMLから保存した
+    direction要素を反転後の正しい小節に挿入する。
+
+    経過的テンポ（rit., accel.等）のwordsテキストには←記号を付与する。
+
+    Args:
+        output_xml_path: 出力MusicXMLファイル(.xml または .mxl)
+        original_layout_map: 元のレイアウト情報（direction要素を含む）
+        total_measures: 総小節数（反転計算用）
+    """
+    # ファイルを読み込み
+    is_mxl = output_xml_path.suffix == '.mxl'
+
+    if is_mxl:
+        root, xml_filename = _extract_mxl_content(output_xml_path)
+    else:
+        tree = ET.parse(output_xml_path)
+        root = tree.getroot()
+
+    # 各パートを処理
+    for part_idx, part in enumerate(root.findall('.//{*}part')):
+        part_id = part.get('id', f'P{part_idx + 1}')
+
+        if part_id not in original_layout_map.directions:
+            continue
+
+        # 小節をインデックスでアクセスできるようにマップを作成
+        measure_map = {}
+        for measure in part.findall('.//{*}measure'):
+            measure_num_str = measure.get('number')
+            if measure_num_str:
+                try:
+                    measure_map[int(measure_num_str)] = measure
+                except ValueError:
+                    pass
+
+        # 各小節からmusic21が生成したdirection要素を削除
+        for measure in part.findall('.//{*}measure'):
+            directions_to_remove = list(measure.findall('{*}direction'))
+            for d in directions_to_remove:
+                measure.remove(d)
+
+        # 保存したdirection要素を反転後の小節に挿入
+        for dir_elem in original_layout_map.directions[part_id]:
+            # 反転後の小節番号を計算（単純な反転）
+            reversed_measure_num = total_measures - dir_elem.measure_num + 1
+
+            if reversed_measure_num not in measure_map:
+                continue
+
+            target_measure = measure_map[reversed_measure_num]
+
+            # direction XMLをパースして要素を復元
+            try:
+                restored_direction = ET.fromstring(dir_elem.direction_xml)
+
+                # 経過的テンポのwordsテキストに←記号を付与
+                if dir_elem.has_words and dir_elem.words_text:
+                    if _is_transitional_tempo_text(dir_elem.words_text):
+                        words_elem = restored_direction.find('.//{*}direction-type/{*}words')
+                        if words_elem is not None and words_elem.text:
+                            if not words_elem.text.startswith('←'):
+                                words_elem.text = '←' + words_elem.text
+
+                # direction要素を小節に挿入
+                # 挿入位置: 小節の先頭（attributesの後）
+                insert_pos = 0
+                for idx, child in enumerate(target_measure):
+                    if child.tag.endswith('attributes'):
+                        insert_pos = idx + 1
+                        break
+
+                target_measure.insert(insert_pos, restored_direction)
+
+            except ET.ParseError:
+                # XMLパースエラーは無視
+                pass
 
     # 変更後のXMLを書き出し
     if is_mxl:

--- a/reverse_score.py
+++ b/reverse_score.py
@@ -1101,34 +1101,29 @@ def process_file(input_path: Path, output_path: Path,
 
             # ========== Phase 3: XML後処理 ==========
             try:
-                # music21のバグで分割されたdirection要素をマージ
-                print(f"  [Phase 3] 分割されたdirection要素をマージ中...")
-                from layout_preservation import merge_split_directions, normalize_slur_numbers
-                merge_split_directions(output_path, verbose=True)
-                print(f"  [Phase 3] direction要素のマージ完了")
+                # direction要素を元のXMLから復元（music21分割バグ対策）
+                print(f"  [Phase 3] direction要素を復元中...")
+                from layout_preservation import restore_direction_elements, normalize_slur_numbers
+                total_measures = len(list(reversed_score.parts[0].getElementsByClass('Measure')))
+                restore_direction_elements(output_path, original_layout, total_measures)
+                print(f"  [Phase 3] direction要素の復元完了")
 
                 # スラーのnumber属性を正規化
                 print(f"  [Phase 3] スラー番号を正規化中...")
                 normalize_slur_numbers(output_path, verbose=False)
                 print(f"  [Phase 3] スラー番号の正規化完了")
-            except Exception as merge_error:
-                print(f"  警告: direction要素のマージに失敗しました: {merge_error}")
+            except Exception as restore_error:
+                print(f"  警告: direction要素の復元に失敗しました: {restore_error}")
                 import traceback
                 traceback.print_exc()
 
             # ========== Phase 4: レイアウト復元 ==========
             if layout_extraction_success and original_layout is not None:
                 print(f"  [Phase 4] レイアウト情報を復元中...")
-                from layout_preservation import apply_layout_to_xml, merge_split_directions
+                from layout_preservation import apply_layout_to_xml
                 try:
-                    total_measures = len(list(reversed_score.parts[0].getElementsByClass('Measure')))
                     apply_layout_to_xml(output_path, original_layout, total_measures)
                     print(f"  [Phase 4] レイアウト復元完了")
-
-                    # レイアウト復元後に再度マージ（XMLシリアライズで再分割される可能性があるため）
-                    print(f"  [Phase 4] direction要素を再マージ中...")
-                    merge_split_directions(output_path, verbose=False)
-                    print(f"  [Phase 4] direction要素の再マージ完了")
                 except Exception as layout_apply_error:
                     print(f"  警告: レイアウト復元に失敗しました: {layout_apply_error}")
                     # レイアウト適用失敗は警告のみ（反転処理自体は成功）

--- a/tests/test_direction_preservation.py
+++ b/tests/test_direction_preservation.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""
+direction要素の保存と復元のテスト
+
+Issue #27: Tempo primo. や rit. などの指示が増殖する問題のリグレッションテスト
+"""
+
+import sys
+import zipfile
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from music21 import converter, stream, expressions, tempo
+from layout_preservation import (
+    extract_layout_from_xml,
+    restore_direction_elements,
+    DirectionElement,
+    LayoutMap,
+    _is_transitional_tempo_text,
+)
+from reverse_score import reverse_score
+
+
+def count_directions_in_mxl(mxl_path: Path) -> int:
+    """MXLファイル内のdirection要素数をカウント"""
+    with zipfile.ZipFile(mxl_path, 'r') as z:
+        for name in z.namelist():
+            if (name.endswith('.xml') or name.endswith('.musicxml')) and not name.startswith('META-INF'):
+                content = z.read(name)
+                root = ET.fromstring(content)
+                return len(root.findall('.//direction'))
+    return 0
+
+
+def get_words_texts_from_mxl(mxl_path: Path) -> list[tuple[str, str]]:
+    """MXLファイルから(小節番号, wordsテキスト)のリストを取得"""
+    result = []
+    with zipfile.ZipFile(mxl_path, 'r') as z:
+        for name in z.namelist():
+            if (name.endswith('.xml') or name.endswith('.musicxml')) and not name.startswith('META-INF'):
+                content = z.read(name)
+                root = ET.fromstring(content)
+                for part in root.findall('.//{*}part'):
+                    for measure in part.findall('.//{*}measure'):
+                        measure_num = measure.get('number', '?')
+                        for d in measure.findall('{*}direction'):
+                            words = d.find('.//{*}direction-type/{*}words')
+                            if words is not None and words.text:
+                                text = words.text.strip()
+                                if text:
+                                    result.append((measure_num, text))
+                break
+    return result
+
+
+class TestTransitionalTempoDetection:
+    """経過的テンポ検出のテスト"""
+
+    def test_rit_is_transitional(self):
+        assert _is_transitional_tempo_text('rit.') is True
+        assert _is_transitional_tempo_text('ritardando') is True
+        assert _is_transitional_tempo_text('Rit.') is True
+
+    def test_accel_is_transitional(self):
+        assert _is_transitional_tempo_text('accel.') is True
+        assert _is_transitional_tempo_text('accelerando') is True
+
+    def test_allargando_is_transitional(self):
+        assert _is_transitional_tempo_text('allargando') is True
+        assert _is_transitional_tempo_text('(allargando)') is True
+
+    def test_main_tempo_is_not_transitional(self):
+        assert _is_transitional_tempo_text('Tempo primo.') is False
+        assert _is_transitional_tempo_text('Allegro') is False
+        assert _is_transitional_tempo_text('Molto Maestoso.') is False
+
+    def test_empty_text_is_not_transitional(self):
+        assert _is_transitional_tempo_text('') is False
+        assert _is_transitional_tempo_text(None) is False
+
+
+class TestDirectionExtraction:
+    """direction要素抽出のテスト"""
+
+    def test_extract_directions_from_viola_file(self):
+        """威風堂々Violaファイルからdirection要素を抽出できる"""
+        test_file = Path('work/inbox/威風堂々ラスト_in-Viola.mxl')
+        if not test_file.exists():
+            pytest.skip(f"Test file not found: {test_file}")
+
+        layout_map = extract_layout_from_xml(test_file)
+
+        # direction要素が抽出されていることを確認
+        total_directions = sum(len(dirs) for dirs in layout_map.directions.values())
+        assert total_directions == 24, f"Expected 24 directions, got {total_directions}"
+
+    def test_direction_element_attributes(self):
+        """DirectionElementの属性が正しく設定される"""
+        test_file = Path('work/inbox/威風堂々ラスト_in-Viola.mxl')
+        if not test_file.exists():
+            pytest.skip(f"Test file not found: {test_file}")
+
+        layout_map = extract_layout_from_xml(test_file)
+
+        # 最初のパートのdirection要素を確認
+        part_id = list(layout_map.directions.keys())[0]
+        directions = layout_map.directions[part_id]
+
+        # 小節1にはwordsとsoundを持つdirection要素がある
+        measure_1_dirs = [d for d in directions if d.measure_num == 1]
+        assert len(measure_1_dirs) >= 3, "Measure 1 should have at least 3 direction elements"
+
+        # words+soundの組み合わせがあることを確認
+        has_words_and_sound = any(d.has_words and d.has_sound for d in measure_1_dirs)
+        assert has_words_and_sound, "Measure 1 should have direction with both words and sound"
+
+
+class TestDirectionRestoration:
+    """direction要素復元のテスト"""
+
+    def test_roundtrip_preserves_direction_count(self, tmp_path):
+        """反転処理後もdirection要素数が保持される"""
+        input_file = Path('work/inbox/威風堂々ラスト_in-Viola.mxl')
+        if not input_file.exists():
+            pytest.skip(f"Test file not found: {input_file}")
+
+        output_file = tmp_path / 'test_output.mxl'
+
+        # Phase 1: レイアウト抽出
+        layout_map = extract_layout_from_xml(input_file)
+
+        # Phase 2: 反転処理
+        score = converter.parse(str(input_file))
+        reversed_score = reverse_score(score, None)
+        reversed_score.write('mxl', fp=str(output_file))
+
+        # Phase 3: direction要素復元
+        total_measures = len(list(reversed_score.parts[0].getElementsByClass('Measure')))
+        restore_direction_elements(output_file, layout_map, total_measures)
+
+        # 検証
+        input_count = count_directions_in_mxl(input_file)
+        output_count = count_directions_in_mxl(output_file)
+
+        assert output_count == input_count, f"Direction count mismatch: input={input_count}, output={output_count}"
+
+    def test_transitional_tempo_gets_arrow(self, tmp_path):
+        """経過的テンポには←記号が付与される"""
+        input_file = Path('work/inbox/威風堂々ラスト_in-Viola.mxl')
+        if not input_file.exists():
+            pytest.skip(f"Test file not found: {input_file}")
+
+        output_file = tmp_path / 'test_output.mxl'
+
+        # Phase 1: レイアウト抽出
+        layout_map = extract_layout_from_xml(input_file)
+
+        # Phase 2: 反転処理
+        score = converter.parse(str(input_file))
+        reversed_score = reverse_score(score, None)
+        reversed_score.write('mxl', fp=str(output_file))
+
+        # Phase 3: direction要素復元
+        total_measures = len(list(reversed_score.parts[0].getElementsByClass('Measure')))
+        restore_direction_elements(output_file, layout_map, total_measures)
+
+        # 検証
+        words_list = get_words_texts_from_mxl(output_file)
+
+        # rit. には←が付与されている
+        rit_texts = [text for measure, text in words_list if 'rit' in text.lower()]
+        assert all(text.startswith('←') for text in rit_texts), "rit. should have ← prefix"
+
+        # allargando には←が付与されている
+        allarg_texts = [text for measure, text in words_list if 'allargando' in text.lower()]
+        assert all(text.startswith('←') for text in allarg_texts), "(allargando) should have ← prefix"
+
+        # Tempo primo. には←が付与されていない
+        tempo_primo_texts = [text for measure, text in words_list if 'Tempo primo' in text]
+        assert all(not text.startswith('←') for text in tempo_primo_texts), "Tempo primo should NOT have ← prefix"
+
+
+class TestIssue27Regression:
+    """Issue #27のリグレッションテスト"""
+
+    def test_no_direction_multiplication(self, tmp_path):
+        """direction要素が増殖しない"""
+        input_file = Path('work/inbox/威風堂々ラスト_in-Viola.mxl')
+        if not input_file.exists():
+            pytest.skip(f"Test file not found: {input_file}")
+
+        output_file = tmp_path / 'test_output.mxl'
+
+        # Phase 1: レイアウト抽出
+        layout_map = extract_layout_from_xml(input_file)
+
+        # Phase 2: 反転処理
+        score = converter.parse(str(input_file))
+        reversed_score = reverse_score(score, None)
+        reversed_score.write('mxl', fp=str(output_file))
+
+        # Phase 3: direction要素復元
+        total_measures = len(list(reversed_score.parts[0].getElementsByClass('Measure')))
+        restore_direction_elements(output_file, layout_map, total_measures)
+
+        # 検証
+        input_count = count_directions_in_mxl(input_file)
+        output_count = count_directions_in_mxl(output_file)
+
+        # direction要素数は同じであるべき
+        assert output_count == input_count, f"Direction elements multiplied: {input_count} -> {output_count}"


### PR DESCRIPTION
## Summary
- music21がdirection要素（words+sound）を分割・複製するバグの根本的な解決
- direction要素をXML文字列として保存し、反転後に復元する方式に変更
- 経過的テンポ（rit., accel.等）には←記号を付与

## 問題
music21がMusicXMLのdirection要素を読み込んで書き出す際に:
1. `words+sound`を含む単一の要素を2つに分割する
2. テンポ反転処理により、分割された要素が異なる小節に出力される

これにより、入力24個のdirection要素が出力で29個に増殖していた。

## 解決策
direction要素をXMLレベルで保存し、反転後に復元することで、music21の分割バグを完全に回避。

## 変更内容
- `DirectionElement`データクラス追加
- `extract_layout_from_xml()`拡張: direction要素を抽出・保存
- `restore_direction_elements()`新規追加: 保存したdirection要素を反転後の小節に復元
- `process_file()`修正: `merge_split_directions`を`restore_direction_elements`に置換
- リグレッションテスト追加

## Test plan
- [x] 威風堂々ラスト_in-Viola.mxlで反転実行
- [x] 入力24個 → 出力24個（増殖なし）を確認
- [x] 経過的テンポ（rit., allargando）に←記号が付与されることを確認
- [x] 全29テストがパス