### PR TITLE
fix: ダイナミクスdirection復元時の default-x/relative-x 残留を修正 (Closes #30)

### DIFF
--- a/layout_preservation.py
+++ b/layout_preservation.py
@@ -793,6 +793,21 @@ def _separate_wedge_pairs(
     return pairs, others
 
 
+def _strip_dynamics_x_attributes(direction_root: ET.Element) -> None:
+    """direction 内の <dynamics> から default-x/relative-x を除去する。
+
+    時間反転に伴い音符の水平位置が変化するため、保存時の元 default-x を
+    そのまま復元すると音符との位置がずれる（Issue #30 と同様の問題）。
+    X 座標は楽譜ソフト/music21 の自動配置に任せ、ここでは Y 座標と
+    placement のみが復元 XML に残るようにする。
+    """
+    for dyn in direction_root.iter():
+        if dyn.tag.endswith('dynamics'):
+            for attr in ('default-x', 'relative-x'):
+                if attr in dyn.attrib:
+                    del dyn.attrib[attr]
+
+
 def _is_tempo_direction(dir_elem: DirectionElement) -> bool:
     """direction要素がテンポ関連かどうかを判定する
 
@@ -941,6 +956,7 @@ def restore_direction_elements(
 
             try:
                 restored_direction = ET.fromstring(dir_elem.direction_xml)
+                _strip_dynamics_x_attributes(restored_direction)
 
                 # 経過的テンポのwordsテキストに←記号を付与
                 if dir_elem.words_text and _is_transitional_tempo_text(dir_elem.words_text):
@@ -968,6 +984,7 @@ def restore_direction_elements(
                 if new_start_measure in measure_map:
                     target = measure_map[new_start_measure]
                     new_start_xml = ET.fromstring(start_dir.direction_xml)
+                    _strip_dynamics_x_attributes(new_start_xml)
                     wedge_elem = new_start_xml.find('.//{*}direction-type/{*}wedge')
                     if wedge_elem is not None:
                         cur_type = wedge_elem.get('type')
@@ -982,6 +999,7 @@ def restore_direction_elements(
                 if new_stop_measure in measure_map:
                     target = measure_map[new_stop_measure]
                     new_stop_xml = ET.fromstring(stop_dir.direction_xml)
+                    _strip_dynamics_x_attributes(new_stop_xml)
                     target_dur = start_dir.measure_duration_quarters
                     target_offset = max(0.0, target_dur - start_dir.offset_quarters)
                     _insert_direction_at_offset(
@@ -1001,6 +1019,7 @@ def restore_direction_elements(
 
             try:
                 restored_direction = ET.fromstring(dir_elem.direction_xml)
+                _strip_dynamics_x_attributes(restored_direction)
                 _insert_into_measure(target_measure, restored_direction)
             except ET.ParseError:
                 pass


### PR DESCRIPTION
## Summary
- Issue #30 の再発を修正。`restore_direction_elements` が保存済み direction の XML をそのまま挿入するため、`<dynamics>` の元 `default-x`/`relative-x` が反転後の出力に残り、音符との水平位置がずれていた。
- `_strip_dynamics_x_attributes` ヘルパーを追加し、direction 復元の3経路（テンポ / wedge start / wedge stop / その他）すべてで挿入直前に `<dynamics>` の `default-x`/`relative-x` を除去。
- X 座標は楽譜ソフト/music21 の自動配置に委ねる（PR #36 と同じ原則）。Y 座標 / placement は従来どおり保持。

## 再発の経緯
1. PR #36 (Issue #30 修正) — `transform_layout_for_reversal()` で `default-x`/`relative-x` を `None` に設定し `apply_layout_to_xml` 経由の不整合を解消。
2. その後追加された `restore_direction_elements` (commit 35e8d09) が、保存済み direction の XML 文字列を**そのまま**挿入する別経路を作り、`<dynamics>` の元 `default-x` が結果ファイルに残るようになった。`apply_layout_to_xml` は `transformed.default_x is not None` のときしか属性を上書きしないため、新経路を経由した属性は除去されず再発。

## 検証
威風堂々ラスト_in-Viola.mxl で確認:

**修正前 (反転後 m=2 / 元 m52 の sf):**
```
dyn.attrib={'default-x': '5.79', 'default-y': '-42.32', 'relative-y': '-25'}
```

**修正後:**
```
dyn.attrib={'default-y': '-42.32', 'relative-y': '-25'}
```

## Test plan
- [x] `pytest tests/` 全 29 件 PASS
- [x] 威風堂々ラスト_in-Viola.mxl を反転して `<dynamics>` から `default-x`/`relative-x` が出力されないことを確認
- [x] `default-y`/`relative-y`/`placement` は保持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)