### PR TITLE
fix: 練習番号の反転後位置を小節境界基準に修正 (Closes #47)

### DIFF
--- a/layout_preservation.py
+++ b/layout_preservation.py
@@ -72,6 +72,7 @@ class DirectionElement:
     words_text: Optional[str] = None  # wordsのテキスト内容
     offset_quarters: float = 0.0  # 小節内オフセット（四分音符単位）
     measure_duration_quarters: float = 0.0  # 小節全体の長さ（四分音符単位）
+    has_rehearsal: bool = False  # rehearsal（練習番号）子要素を持つか
 
 
 @dataclass
@@ -248,9 +249,11 @@ def extract_layout_from_xml(xml_path: Path) -> LayoutMap:
                     placement = elem.get('placement')
                     sound = elem.find('.//{*}sound')
                     words = elem.find('.//{*}direction-type/{*}words')
+                    rehearsal = elem.find('.//{*}direction-type/{*}rehearsal')
 
                     has_sound = sound is not None
                     has_words = words is not None
+                    has_rehearsal = rehearsal is not None
                     words_text = None
                     if words is not None and words.text:
                         words_text = words.text.strip()
@@ -274,6 +277,7 @@ def extract_layout_from_xml(xml_path: Path) -> LayoutMap:
                         words_text=words_text,
                         offset_quarters=current_offset + _direction_offset_q,
                         measure_duration_quarters=measure_duration_quarters,
+                        has_rehearsal=has_rehearsal,
                     )
                     layout_map.directions[part_id].append(direction_elem)
                     direction_index += 1
@@ -948,7 +952,9 @@ def restore_direction_elements(
         all_directions = original_layout_map.directions[part_id]
         wedge_pairs, non_wedge_dirs = _separate_wedge_pairs(all_directions)
         tempo_directions = [d for d in non_wedge_dirs if _is_tempo_direction(d)]
-        other_directions = [d for d in non_wedge_dirs if not _is_tempo_direction(d)]
+        non_tempo_dirs = [d for d in non_wedge_dirs if not _is_tempo_direction(d)]
+        rehearsal_directions = [d for d in non_tempo_dirs if d.has_rehearsal]
+        other_directions = [d for d in non_tempo_dirs if not d.has_rehearsal]
 
         def _insert_into_measure(target_measure, restored):
             insert_pos = 0
@@ -1030,6 +1036,28 @@ def restore_direction_elements(
         # 3. その他のdirection要素は単純な位置反転で挿入
         for dir_elem in other_directions:
             reversed_measure_num = total_measures - dir_elem.measure_num + 1
+
+            if reversed_measure_num not in measure_map:
+                continue
+
+            target_measure = measure_map[reversed_measure_num]
+
+            try:
+                restored_direction = ET.fromstring(dir_elem.direction_xml)
+                _strip_dynamics_x_attributes(restored_direction)
+                _insert_into_measure(target_measure, restored_direction)
+            except ET.ParseError:
+                pass
+
+        # 4. 練習番号（rehearsal）は小節境界に紐付くため +1 シフトした位置に挿入
+        # 元 m_N の頭の練習番号 = m_(N-1) と m_N の境界。時間反転すると
+        # その境界は反転後 m_(total-N+1) と m_(total-N+2) の間になり、
+        # MusicXML上は反転後 m_(total-N+2) の頭に置く。
+        for dir_elem in rehearsal_directions:
+            reversed_measure_num = total_measures - dir_elem.measure_num + 2
+            if reversed_measure_num > total_measures:
+                # 元 m_1 の練習番号は反転後では曲末に対応するため最終小節に置く
+                reversed_measure_num = total_measures
 
             if reversed_measure_num not in measure_map:
                 continue

--- a/tests/test_direction_preservation.py
+++ b/tests/test_direction_preservation.py
@@ -213,3 +213,55 @@ class TestIssue27Regression:
 
         # direction要素数は同じであるべき
         assert output_count == input_count, f"Direction elements multiplied: {input_count} -> {output_count}"
+
+
+def get_rehearsal_marks_from_mxl(mxl_path: Path) -> list[tuple[str, str]]:
+    """MXLファイルから(小節番号, 練習番号テキスト)のリストを取得"""
+    result = []
+    with zipfile.ZipFile(mxl_path, 'r') as z:
+        for name in z.namelist():
+            if (name.endswith('.xml') or name.endswith('.musicxml')) and not name.startswith('META-INF'):
+                content = z.read(name)
+                root = ET.fromstring(content)
+                for part in root.findall('.//{*}part'):
+                    for measure in part.findall('.//{*}measure'):
+                        measure_num = measure.get('number', '?')
+                        for d in measure.findall('{*}direction'):
+                            r = d.find('.//{*}direction-type/{*}rehearsal')
+                            if r is not None and r.text:
+                                result.append((measure_num, r.text.strip()))
+                break
+    return result
+
+
+class TestIssue47RehearsalMarkPosition:
+    """Issue #47: 練習番号の反転位置が小節境界に正しく対応する"""
+
+    def test_rehearsal_marks_shifted_by_one_measure(self, tmp_path):
+        """練習番号は反転後 total - N + 2 に配置される（境界貼付）"""
+        input_file = Path('work/inbox/威風堂々ラスト_in-Viola.mxl')
+        if not input_file.exists():
+            pytest.skip(f"Test file not found: {input_file}")
+
+        output_file = tmp_path / 'test_output.mxl'
+
+        layout_map = extract_layout_from_xml(input_file)
+        score = converter.parse(str(input_file))
+        reversed_score = reverse_score(score, None)
+        reversed_score.write('mxl', fp=str(output_file))
+        total_measures = len(list(reversed_score.parts[0].getElementsByClass('Measure')))
+        restore_direction_elements(output_file, layout_map, total_measures)
+
+        marks = get_rehearsal_marks_from_mxl(output_file)
+        # 元: S at m17, T at m41, total=53 → 反転後: S at m38, T at m14
+        mark_measures = {text: measure for measure, text in marks}
+        assert mark_measures.get('T') == '14', \
+            f"T should be at measure 14 (between m13 and m14), got {mark_measures.get('T')}"
+        assert mark_measures.get('S') == '38', \
+            f"S should be at measure 38, got {mark_measures.get('S')}"
+
+        # 旧バグ位置 (m13, m37) には練習番号が無いこと
+        old_bug_measures = {measure for measure, _ in marks}
+        assert '13' not in old_bug_measures or all(
+            text not in ('S', 'T') for measure, text in marks if measure == '13'
+        ), "Rehearsal mark wrongly at measure 13 (off-by-one regression)"


### PR DESCRIPTION
## Summary
- 反転後に練習番号（rehearsal mark）が1小節分前に配置されるバグを修正
- 練習番号は意味的に小節境界に紐付くため、`reversed = total - N + 2` で配置
- `威風堂々ラスト_in-Viola.mxl`: `T` が m13→m14、`S` が m37→m38 に正しく移動

## Root cause
練習番号は MusicXML 上は「ある小節の先頭（offset 0）」として書かれるが、視覚的・意味的には**直前のバーライン**に紐付く。
他の direction と同じ単純反転 `total - N + 1` を適用していたため、小節1つ分早い位置に置かれていた。

時間反転で「元 m_N の左バーライン」は「反転後 m_(total-N+1) の右バーライン = m_(total-N+2) の左バーライン」に対応するため、練習番号だけは +1 シフトが必要。

## Changes
- `layout_preservation.py`:
  - `DirectionElement.has_rehearsal` フィールド追加
  - 抽出時に `<direction-type>/<rehearsal>` の有無を検出
  - `restore_direction_elements` で練習番号を専用ループで `total - N + 2` 位置に配置（原 m1 の場合は最終小節へクランプ）
- `tests/test_direction_preservation.py`:
  - `TestIssue47RehearsalMarkPosition` 追加（T@m14, S@m38 を検証）

## Test plan
- [x] `python -m pytest tests/ -v` → 30 passed
- [x] `威風堂々ラスト_in-Viola.mxl` を反転して `T` が m14、`S` が m38 にあることを XML 解析で確認
- [ ] MuseScore 等で反転後ファイルを開き、練習番号が想定の小節境界に表示されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)