### PR TITLE
fix: ダイナミクス記号の反転後位置が正しくなるよう修正 (Closes #54)

### DIFF
--- a/layout_preservation.py
+++ b/layout_preservation.py
@@ -684,6 +684,59 @@ def _measure_total_quarters(measure: ET.Element, divisions: float) -> float:
     return max_offset
 
 
+def _compute_reversed_insert_offset(
+    reversed_measure: ET.Element,
+    original_offset_q: float,
+    measure_duration_q: float,
+    divisions: float,
+) -> float:
+    """元の measure の original_offset_q に紐付く direction を
+    反転後の measure に挿入する際の目標オフセットを計算する。
+
+    反転後の measure を走査し、終端時刻が
+    (measure_duration_q - original_offset_q) を超える
+    最初の非コード音符の開始位置を返す。これにより、direction が
+    元の音符と同じ音符の直前に挿入される。
+    """
+    epsilon = 1e-6
+    target_end = measure_duration_q - original_offset_q
+
+    if target_end <= epsilon:
+        return 0.0  # 小節冒頭に挿入
+
+    cumulative = 0.0
+    for child in reversed_measure:
+        tag = child.tag
+        if tag.endswith('note'):
+            if child.find('.//{*}chord') is None:
+                d = child.find('.//{*}duration')
+                dur = 0.0
+                if d is not None and d.text:
+                    try:
+                        dur = float(d.text) / divisions
+                    except ValueError:
+                        pass
+                if cumulative + dur > target_end - epsilon:
+                    return cumulative
+                cumulative += dur
+        elif tag.endswith('backup'):
+            d = child.find('.//{*}duration')
+            if d is not None and d.text:
+                try:
+                    cumulative = max(0.0, cumulative - float(d.text) / divisions)
+                except ValueError:
+                    pass
+        elif tag.endswith('forward'):
+            d = child.find('.//{*}duration')
+            if d is not None and d.text:
+                try:
+                    cumulative += float(d.text) / divisions
+                except ValueError:
+                    pass
+
+    return measure_duration_q  # フォールバック: 末尾に追加
+
+
 def _insert_direction_at_offset(
     measure: ET.Element,
     direction: ET.Element,
@@ -1033,7 +1086,7 @@ def restore_direction_elements(
             except ET.ParseError:
                 pass
 
-        # 3. その他のdirection要素は単純な位置反転で挿入
+        # 3. その他のdirection要素（ダイナミクス等）は小節内オフセットを反転して挿入
         for dir_elem in other_directions:
             reversed_measure_num = total_measures - dir_elem.measure_num + 1
 
@@ -1045,7 +1098,15 @@ def restore_direction_elements(
             try:
                 restored_direction = ET.fromstring(dir_elem.direction_xml)
                 _strip_dynamics_x_attributes(restored_direction)
-                _insert_into_measure(target_measure, restored_direction)
+                target_offset = _compute_reversed_insert_offset(
+                    target_measure,
+                    dir_elem.offset_quarters,
+                    dir_elem.measure_duration_quarters,
+                    part_divisions,
+                )
+                _insert_direction_at_offset(
+                    target_measure, restored_direction, target_offset, part_divisions
+                )
             except ET.ParseError:
                 pass
 

--- a/tests/test_direction_preservation.py
+++ b/tests/test_direction_preservation.py
@@ -265,3 +265,73 @@ class TestIssue47RehearsalMarkPosition:
         assert '13' not in old_bug_measures or all(
             text not in ('S', 'T') for measure, text in marks if measure == '13'
         ), "Rehearsal mark wrongly at measure 13 (off-by-one regression)"
+
+
+def get_dynamics_positions_from_mxl(mxl_path: Path) -> list[tuple[str, float, str]]:
+    """MXLファイルから(小節番号, 小節内オフセット_quarters, ダイナミクス種別)を取得"""
+    result = []
+    with zipfile.ZipFile(mxl_path, 'r') as z:
+        for name in z.namelist():
+            if (name.endswith('.xml') or name.endswith('.musicxml')) and not name.startswith('META-INF'):
+                content = z.read(name)
+                root = ET.fromstring(content)
+                for part in root.findall('.//{*}part'):
+                    divs = 1.0
+                    for measure in part.findall('.//{*}measure'):
+                        measure_num = measure.get('number', '?')
+                        current_offset = 0.0
+                        for elem in measure:
+                            tag = elem.tag.split('}')[-1]
+                            if tag == 'attributes':
+                                d = elem.find('.//{*}divisions')
+                                if d is not None and d.text:
+                                    divs = float(d.text)
+                            elif tag == 'direction':
+                                dyn = elem.find('.//{*}dynamics')
+                                if dyn is not None:
+                                    for ch in dyn:
+                                        dyn_type = ch.tag.split('}')[-1]
+                                        result.append((measure_num, current_offset / divs, dyn_type))
+                            elif tag == 'note':
+                                chord = elem.find('.//{*}chord')
+                                dur_e = elem.find('.//{*}duration')
+                                if chord is None and dur_e is not None and dur_e.text:
+                                    current_offset += float(dur_e.text)
+                break
+    return result
+
+
+class TestIssue54DynamicsPosition:
+    """Issue #54: ダイナミクス記号の反転後位置が正しい"""
+
+    def test_dynamics_on_last_beat_after_reversal(self, tmp_path):
+        """1拍目のffは反転後に最後の拍（2拍目）に配置される"""
+        input_file = Path('work/inbox/威風堂々ラスト_in-Viola.mxl')
+        if not input_file.exists():
+            pytest.skip(f"Test file not found: {input_file}")
+
+        output_file = tmp_path / 'test_output.mxl'
+
+        layout_map = extract_layout_from_xml(input_file)
+        score = converter.parse(str(input_file))
+        reversed_score = reverse_score(score, None)
+        reversed_score.write('mxl', fp=str(output_file))
+        total_measures = len(list(reversed_score.parts[0].getElementsByClass('Measure')))
+        restore_direction_elements(output_file, layout_map, total_measures)
+
+        positions = get_dynamics_positions_from_mxl(output_file)
+
+        # 元の1小節目の1拍目(offset=0q)にffがある
+        # 反転後、最終小節(m53)の2拍目(offset=1q)にffが来るはず
+        last_measure_str = str(total_measures)
+        ff_positions = [
+            (m, offset) for m, offset, dyn in positions
+            if dyn == 'ff' and m == last_measure_str
+        ]
+
+        assert len(ff_positions) >= 1, "ff should appear in the last reversed measure"
+        for measure_num, offset in ff_positions:
+            assert offset > 0.0, (
+                f"ff at measure {measure_num} offset {offset}q: "
+                f"should be on beat 2 (offset > 0), not beat 1"
+            )


### PR DESCRIPTION
## Summary

- `_compute_reversed_insert_offset()` ヘルパー関数を追加し、反転後の小節に direction 要素を挿入する際の正しいオフセットを計算するようにした
- 従来は `other_directions`（ダイナミクス等）が常に小節冒頭（attributes 直後）に挿入されていたため、例えば1拍目の ff が反転後も1拍目に置かれてしまっていた
- 修正後は、元の offset `O` にある direction が反転後の小節では `measure_duration - O` を終端時刻とする音符の直前に挿入される

## 原因

`restore_directions_to_output` のセクション3（その他の direction）で `_insert_into_measure` を使っており、これは常に attributes の直後（小節冒頭）に挿入していた。ダイナミクスの小節内時間位置が無視されていた。

## 修正内容

- `layout_preservation.py`: `_compute_reversed_insert_offset()` を追加し、反転後のオフセットを計算。セクション3の `_insert_into_measure` を `_insert_direction_at_offset` + 新関数に置き換え
- `tests/test_direction_preservation.py`: Issue #54 のリグレッションテスト `TestIssue54DynamicsPosition` を追加

## Test plan

- [x] 全既存テスト (30件) PASS
- [x] 新テスト `test_dynamics_on_last_beat_after_reversal` PASS
- [x] 威風堂々ラスト_in-Viola.mxl で実際に反転処理を実行し、measure 53 (元の measure 1) の ff が offset=1q (2拍目) に配置されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)