### PR TITLE
fix: SystemLayout/StaffLayoutの反転位置計算を有効範囲ベースに修正 (Closes #61)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ __pycache__/
 *.egg-info/
 dist/
 build/
+.venv/
 
 # IDE
 .vscode/

--- a/reverse_score.py
+++ b/reverse_score.py
@@ -14,7 +14,7 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from music21 import converter, stream, dynamics, tie, spanner, clef, expressions
+from music21 import converter, stream, dynamics, tie, spanner, clef, expressions, layout
 from music21.spanner import Ottava
 
 
@@ -331,6 +331,91 @@ def apply_reversed_clefs(
             if measure.number == target_measure_num:
                 # 小節の先頭に音部記号を挿入
                 measure.insert(0, pos['clef'])
+                break
+
+
+def collect_layout_positions(measures: list[stream.Measure], class_name: str) -> list[dict]:
+    """パート内の全レイアウト要素（SystemLayout, StaffLayout, PageLayout）と小節番号を収集する
+
+    <print> 要素から生成される SystemLayout/StaffLayout/PageLayout は、
+    音部記号と同様に「この小節から次の同種要素が出現するまで有効」という
+    始点のみ指定される要素のため、Clef と同じ反転ロジックを使う。
+
+    Args:
+        measures: 小節のリスト（元の順序）
+        class_name: 収集するレイアウト要素のクラス名（'SystemLayout' 等）
+
+    Returns:
+        レイアウト要素の情報リスト [{measure_num, offset, layout_obj}]
+    """
+    layout_positions = []
+
+    for measure in measures:
+        for layout_obj in measure.getElementsByClass(class_name):
+            layout_positions.append({
+                'measure_num': measure.number,
+                'offset': layout_obj.offset,
+                'layout_obj': layout_obj,
+            })
+
+    layout_positions.sort(key=lambda x: (x['measure_num'], x['offset']))
+    return layout_positions
+
+
+def calculate_reversed_layout_positions(
+    layout_positions: list[dict],
+    total_measures: int
+) -> list[dict]:
+    """レイアウト要素の反転後位置を計算する（calculate_reversed_clef_positions と同じロジック）
+
+    Args:
+        layout_positions: collect_layout_positions() の結果
+        total_measures: 総小節数
+
+    Returns:
+        反転後の位置情報 [{reversed_measure_num, layout_obj}]
+    """
+    if not layout_positions:
+        return []
+
+    reversed_positions = []
+
+    for i, pos in enumerate(layout_positions):
+        if i + 1 < len(layout_positions):
+            effective_end = layout_positions[i + 1]['measure_num'] - 1
+        else:
+            effective_end = total_measures
+
+        reversed_start = total_measures - effective_end + 1
+
+        reversed_positions.append({
+            'reversed_measure_num': reversed_start,
+            'layout_obj': copy.deepcopy(pos['layout_obj']),
+        })
+
+    reversed_positions.sort(key=lambda x: x['reversed_measure_num'])
+    return reversed_positions
+
+
+def apply_reversed_layout_elements(
+    new_part: stream.Part,
+    reversed_layout_positions: list[dict]
+) -> None:
+    """反転後のパートにレイアウト要素を挿入する
+
+    Clef とは異なり、元の <print> は小節の子要素として現れるため、
+    最初の要素もパートレベルではなく対象小節に挿入する。
+
+    Args:
+        new_part: 反転後のパート（小節が追加済み）
+        reversed_layout_positions: calculate_reversed_layout_positions() の結果
+    """
+    for pos in reversed_layout_positions:
+        target_measure_num = pos['reversed_measure_num']
+
+        for measure in new_part.getElementsByClass(stream.Measure):
+            if measure.number == target_measure_num:
+                measure.insert(0, pos['layout_obj'])
                 break
 
 
@@ -670,6 +755,12 @@ def reverse_part(part: stream.Part | stream.PartStaff, report: ProcessingReport 
     # テンポ要素も同様に反転ロジックで処理
     tempo_positions = collect_tempo_positions(measures)
 
+    # <print> から生成されるレイアウト要素も同様に反転ロジックで処理
+    # （種類ごとに独立した「始点のみ要素」の系列として扱う）
+    system_layout_positions = collect_layout_positions(measures, 'SystemLayout')
+    staff_layout_positions = collect_layout_positions(measures, 'StaffLayout')
+    page_layout_positions = collect_layout_positions(measures, 'PageLayout')
+
     # 調号をコピー (KeySignature)
     key_sigs = first_original_measure.getElementsByClass('KeySignature')
     if key_sigs:
@@ -703,6 +794,11 @@ def reverse_part(part: stream.Part | stream.PartStaff, report: ProcessingReport 
         # 音部記号を小節から削除（反転ロジックで再配置するため）
         for elem in list(measure_to_process.getElementsByClass('Clef')):
             measure_to_process.remove(elem)
+
+        # レイアウト要素（System/Staff/PageLayout）を小節から削除（反転ロジックで再配置するため）
+        for layout_class in ['SystemLayout', 'StaffLayout', 'PageLayout']:
+            for elem in list(measure_to_process.getElementsByClass(layout_class)):
+                measure_to_process.remove(elem)
 
         # 小節内の音符を反転
         processed_measure, error = reverse_measure_contents(measure_to_process)
@@ -775,6 +871,11 @@ def reverse_part(part: stream.Part | stream.PartStaff, report: ProcessingReport 
     # テンポ要素を反転して適用
     reversed_tempo_positions = calculate_reversed_tempo_positions(tempo_positions, total_measures)
     apply_reversed_tempo_elements(new_part, reversed_tempo_positions)
+
+    # レイアウト要素（System/Staff/PageLayout）を反転して適用
+    for positions in (system_layout_positions, staff_layout_positions, page_layout_positions):
+        reversed_positions = calculate_reversed_layout_positions(positions, total_measures)
+        apply_reversed_layout_elements(new_part, reversed_positions)
 
     # 保存したSpanner情報を使って、新しいパートでSpannerを再構築
     for sp_info in spanner_info:

--- a/tests/test_position_adjustment.py
+++ b/tests/test_position_adjustment.py
@@ -6,7 +6,7 @@ Issue #29: 音部記号、テンポ指示など「始点のみ指定される要
 """
 
 import pytest
-from music21 import stream, clef, tempo, note, expressions
+from music21 import stream, clef, tempo, note, expressions, layout
 
 import sys
 from pathlib import Path
@@ -19,6 +19,9 @@ from reverse_score import (
     collect_tempo_positions,
     calculate_reversed_tempo_positions,
     apply_reversed_tempo_elements,
+    collect_layout_positions,
+    calculate_reversed_layout_positions,
+    apply_reversed_layout_elements,
     reverse_part,
     is_transitional_tempo,
 )
@@ -127,6 +130,104 @@ class TestClefPositionCalculation:
         # m1のC → 反転後m9
         assert reversed_positions[2]['reversed_measure_num'] == 9
         assert isinstance(reversed_positions[2]['clef'], clef.AltoClef)
+
+
+class TestLayoutPositionCollection:
+    """レイアウト要素（SystemLayout/StaffLayout）の位置収集テスト
+
+    Issue #61: <print> から生成される SystemLayout/StaffLayout は
+    音部記号と同じ「始点のみ指定される要素」だが、反転時に再配置されず
+    元の小節と一緒に移動してしまい、スコアの大部分が元のスペーシングを
+    失って行間が広がる原因になっていた。
+    """
+
+    def test_single_system_layout(self):
+        """単一SystemLayoutの収集（威風堂々-Violinパターン）"""
+        measures = []
+        for i in range(1, 6):
+            m = stream.Measure(number=i)
+            if i == 1:
+                sl = layout.SystemLayout()
+                sl.topDistance = 305.89
+                m.insert(0, sl)
+            m.append(note.Rest(quarterLength=4))
+            measures.append(m)
+
+        positions = collect_layout_positions(measures, 'SystemLayout')
+        assert len(positions) == 1
+        assert positions[0]['measure_num'] == 1
+        assert isinstance(positions[0]['layout_obj'], layout.SystemLayout)
+
+    def test_multiple_staff_layouts(self):
+        """複数StaffLayoutの収集"""
+        measures = []
+        for i in range(1, 11):
+            m = stream.Measure(number=i)
+            if i == 1:
+                m.insert(0, layout.StaffLayout(distance=78.44))
+            elif i == 6:
+                m.insert(0, layout.StaffLayout(distance=100.0))
+            m.append(note.Rest(quarterLength=4))
+            measures.append(m)
+
+        positions = collect_layout_positions(measures, 'StaffLayout')
+        assert len(positions) == 2
+        assert positions[0]['measure_num'] == 1
+        assert positions[1]['measure_num'] == 6
+
+    def test_system_and_staff_layout_independent(self):
+        """SystemLayoutとStaffLayoutは別系列として扱われる"""
+        measures = []
+        for i in range(1, 6):
+            m = stream.Measure(number=i)
+            if i == 1:
+                m.insert(0, layout.SystemLayout())
+                m.insert(0, layout.StaffLayout(distance=78.44))
+            m.append(note.Rest(quarterLength=4))
+            measures.append(m)
+
+        system_positions = collect_layout_positions(measures, 'SystemLayout')
+        staff_positions = collect_layout_positions(measures, 'StaffLayout')
+        assert len(system_positions) == 1
+        assert len(staff_positions) == 1
+
+
+class TestLayoutPositionCalculation:
+    """レイアウト要素の反転位置計算テスト"""
+
+    def test_single_layout_at_measure_one_reversed(self):
+        """measure 1にのみある宣言は反転後もm1に配置される（威風堂々-Violinの実際のバグ）
+
+        元: m1にSystemLayoutのみ、全53小節
+        修正前: ディープコピーで小節と一緒に移動 → m53に配置（バグ）
+        修正後: 53-53+1=1 → m1に配置
+        """
+        positions = [{'measure_num': 1, 'offset': 0, 'layout_obj': layout.SystemLayout()}]
+        total_measures = 53
+
+        reversed_positions = calculate_reversed_layout_positions(positions, total_measures)
+
+        assert len(reversed_positions) == 1
+        assert reversed_positions[0]['reversed_measure_num'] == 1
+
+    def test_two_layouts_reversed(self):
+        """2つのレイアウト宣言の反転"""
+        # m1, m6 → 全10小節
+        # m1はm5まで有効 → 反転後: 10-5+1=6
+        # m6はm10まで有効 → 反転後: 10-10+1=1
+        positions = [
+            {'measure_num': 1, 'offset': 0, 'layout_obj': layout.StaffLayout(distance=78.44)},
+            {'measure_num': 6, 'offset': 0, 'layout_obj': layout.StaffLayout(distance=100.0)},
+        ]
+        total_measures = 10
+
+        reversed_positions = calculate_reversed_layout_positions(positions, total_measures)
+
+        assert len(reversed_positions) == 2
+        assert reversed_positions[0]['reversed_measure_num'] == 1
+        assert reversed_positions[0]['layout_obj'].distance == 100.0
+        assert reversed_positions[1]['reversed_measure_num'] == 6
+        assert reversed_positions[1]['layout_obj'].distance == 78.44
 
 
 class TestTempoPositionCollection:
@@ -257,6 +358,43 @@ class TestReversePartIntegration:
         final_measures = list(reversed_twice.getElementsByClass(stream.Measure))
         assert len(orig_measures) == len(final_measures)
 
+    def test_system_staff_layout_reversal_in_part(self):
+        """パート全体でのSystemLayout/StaffLayout反転（Issue #61）
+
+        m1にのみある宣言は、小節順序の反転後もm1（スコア冒頭）に
+        留まる必要がある。修正前はディープコピーで小節と一緒に
+        最終小節へ移動してしまい、それ以前の全システムがmusic21の
+        デフォルトスペーシングにフォールバックして行間が広がっていた。
+        """
+        part = stream.Part()
+        for i in range(1, 11):
+            m = stream.Measure(number=i)
+            if i == 1:
+                sl = layout.SystemLayout()
+                sl.topDistance = 305.89
+                m.insert(0, sl)
+                m.insert(0, layout.StaffLayout(distance=78.44))
+            m.append(note.Note('C4', quarterLength=4))
+            part.append(m)
+
+        reversed_part = reverse_part(part)
+        measures = list(reversed_part.getElementsByClass(stream.Measure))
+
+        m1 = next(m for m in measures if m.number == 1)
+        system_layouts = list(m1.getElementsByClass('SystemLayout'))
+        staff_layouts = list(m1.getElementsByClass('StaffLayout'))
+
+        assert len(system_layouts) == 1
+        assert system_layouts[0].topDistance == 305.89
+        assert len(staff_layouts) == 1
+        assert staff_layouts[0].distance == 78.44
+
+        # 他の小節には漏れていない
+        for m in measures:
+            if m.number != 1:
+                assert len(list(m.getElementsByClass('SystemLayout'))) == 0
+                assert len(list(m.getElementsByClass('StaffLayout'))) == 0
+
 
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])
@@ -348,6 +486,45 @@ class TestRealDataIntegration:
 
         # 音部記号の種類が保持されていることを確認
         assert original_clef_set == final_clef_set, "音部記号の種類が一致しない"
+
+    def test_ifudodo_violin_layout_file(self):
+        """威風堂々-Violinパートで SystemLayout/StaffLayout の反転を確認（Issue #61）
+
+        実データ: m1にのみ <print>（system-layout, staff-layout）があり、
+        他に <print> はない。反転後もm1に残っている必要がある。
+        修正前はm53（最終小節）に移動してしまっていた。
+        """
+        from music21 import converter
+        from pathlib import Path
+
+        test_file = Path(__file__).parent.parent / 'work/inbox/test/威風堂々ラスト_in-Violin.mxl'
+        if not test_file.exists():
+            pytest.skip(f"Test file not found: {test_file}")
+
+        score = converter.parse(str(test_file))
+
+        for part in score.parts:
+            original_measures = list(part.getElementsByClass(stream.Measure))
+            total_measures = len(original_measures)
+
+            reversed_part = reverse_part(part)
+            reversed_measures = list(reversed_part.getElementsByClass(stream.Measure))
+
+            m1 = next(m for m in reversed_measures if m.number == 1)
+            last_measure = next(m for m in reversed_measures if m.number == total_measures)
+
+            # 最終小節に取り残されていないこと（修正前のバグ）
+            assert len(list(last_measure.getElementsByClass('SystemLayout'))) == 0
+            assert len(list(last_measure.getElementsByClass('StaffLayout'))) == 0
+
+            # 元々レイアウト宣言を持っていたパートはm1に復元されていること
+            original_system_layouts = collect_layout_positions(original_measures, 'SystemLayout')
+            original_staff_layouts = collect_layout_positions(original_measures, 'StaffLayout')
+
+            if original_system_layouts:
+                assert len(list(m1.getElementsByClass('SystemLayout'))) >= 1
+            if original_staff_layouts:
+                assert len(list(m1.getElementsByClass('StaffLayout'))) >= 1
 
 
 class TestTransitionalTempoDetection:


### PR DESCRIPTION
## Summary

- `<print>` から生成される `SystemLayout`/`StaffLayout`/`PageLayout` は、`Clef`/`Tempo`（Issue #29）と同様に「この小節から次の同種要素が出現するまで有効」という始点のみ指定される要素だが、反転時に再配置されず元の小節と一緒にディープコピーされて移動してしまっていた。
- `威風堂々ラスト_in-Violin.mxl` では measure 1 にのみ `system-layout`（`top-system-distance=305.89`）の宣言があり、反転後は最終小節（m53）に移動してしまうため、スコアの大部分が music21 のデフォルトスペーシングにフォールバックし、行間が広がって2ページが3ページに増えていた。
- Issue #29 で Clef/Tempo に実装した「適用終了位置を計算 → 反転後の開始位置を算出」ロジックを `SystemLayout`/`StaffLayout`/`PageLayout` にも適用し、`reverse_part()` 内で小節からの削除・反転後の再挿入を行うように修正した。

## 変更ファイル

- `reverse_score.py`: `collect_layout_positions` / `calculate_reversed_layout_positions` / `apply_reversed_layout_elements` を追加し `reverse_part()` に統合
- `tests/test_position_adjustment.py`: 実データ（`威風堂々ラスト_in-Violin.mxl`）での回帰テストを含むテストを追加

## 検証

- `python -m pytest tests/ test_layout_preservation.py test_all_spanners_v2.py test_beam_preservation.py test_spanner_reversal.py` で 50 passed（既存の無関係な2件の失敗は本修正前から存在するもので、本PRによる回帰ではない）
- `python reverse_score.py -s` で `work/inbox/` 全27ファイルを実行し成功を確認
- 実際の問題ファイル（`威風堂々ラスト_in-Violin.mxl`）の出力XMLを直接検証し、`<print>` 内の `system-layout`（`top-system-distance=305.89`, `system-margins`）が反転後も measure 1 に正しく配置されることを確認（修正前は measure 53 に誤って配置されていた）
- `work/inbox/` 内の全27ファイルで `<print>` 要素数が入力と出力で一致することを確認（位置の取りこぼし・重複なし）

## 既知の関連事項（このPRの範囲外）

調査中に、`威風堂々ラスト_in-Violin.mxl` が2段譜（staffNumber=2、distance=78.44 の `staff-layout`）を持つことが判明し、この `staff-layout` が music21 の書き出し時に消失することを確認した。これは **reversal なしの単純な round-trip でも再現する** music21 側の制約（2つの `PartStaff` を `<staves>2</staves>` の単一 `<part>` にマージする際に発生）であり、本Issue#61の反転位置バグとは別原因のため、本PRのスコア外として別Issueで追跡する予定。
